### PR TITLE
New systems in canscrape list

### DIFF
--- a/fullscrape.sh
+++ b/fullscrape.sh
@@ -6,7 +6,7 @@ IMAGESPATH=$ROMSPATH
 TMP=/tmp
 SCRAPER=$TMP/scraper
 MAMEDEVICES=("mame" "fba" "fba_libretro" "neogeo")
-CANSCRAPE=("${MAMEDEVICES[@]}" "nes" "snes" "n64" "gb" "gbc" "gba" "megadrive" "mastersystem" "sega32x" "gamegear" "pcengine" "atari2600" "lynx" "psx" "scummvm" "segacd" "virtualboy" "sg1000" "ngp" "ngpc" "fds")
+CANSCRAPE=("${MAMEDEVICES[@]}" "nes" "snes" "n64" "gb" "gbc" "gba" "megadrive" "mastersystem" "sega32x" "gamegear" "pcengine" "atari2600" "lynx" "psx" "scummvm" "segacd" "virtualboy" "sg1000" "ngp" "ngpc" "fds" "atari7800" "vectrex" "supergrafx" "o2em")
 ESDAEMON=$(ls /etc/init.d/S*emulationstation)
 
 selectiveMode=0


### PR DESCRIPTION
"atari7800" "vectrex" "supergrafx" "o2em" tested working with NOINTRO set